### PR TITLE
fix:cugan

### DIFF
--- a/archs/realcugan.py
+++ b/archs/realcugan.py
@@ -271,8 +271,10 @@ class cugan(nn.Module):
             out_channels = state_dict["unet2.conv_bottom.weight"].shape[0]
 
         self.scale = scale
-        self.pro_mode = True
-
+        pro = False
+        if list(state_dict.keys())[-1] == "unet2.conv_bottom.bias" or "pro" in state_dict:
+            pro = True
+        self.pro_mode = pro
         if self.scale == 1:
             raise ValueError(f'1x scale ratio is unsupported. Please use 2x, 3x or 4x.')
 

--- a/archs/realcugan.py
+++ b/archs/realcugan.py
@@ -253,7 +253,7 @@ class cugan(nn.Module):
     def __init__(self, state_dict):
         super(cugan, self).__init__()
         self.name = "cugan"
-        pro = False
+
         if "conv_final.weight" in state_dict:
             # UpCunet4x
             scale = 4
@@ -269,10 +269,9 @@ class cugan(nn.Module):
             scale = 2
             in_channels = state_dict["unet1.conv1.conv.0.weight"].shape[1]
             out_channels = state_dict["unet2.conv_bottom.weight"].shape[0]
-        if "pro" in state_dict:
-            pro = True
+
         self.scale = scale
-        self.pro_mode = pro
+        self.pro_mode = True
 
         if self.scale == 1:
             raise ValueError(f'1x scale ratio is unsupported. Please use 2x, 3x or 4x.')


### PR DESCRIPTION
In general, the endless inclusion of the pro mode does not interfere with compatibility, although it may change the output of non-pro models, but this way we get full compatibility with models made on neosr

